### PR TITLE
Prepare github org rename to flatcar

### DIFF
--- a/app-admin/locksmith/locksmith-9999.ebuild
+++ b/app-admin/locksmith/locksmith-9999.ebuild
@@ -2,10 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/locksmith"
+CROS_WORKON_PROJECT="flatcar/locksmith"
 CROS_WORKON_LOCALNAME="locksmith"
 CROS_WORKON_REPO="https://github.com"
-COREOS_GO_PACKAGE="github.com/flatcar-linux/locksmith"
+COREOS_GO_PACKAGE="github.com/flatcar/locksmith"
 inherit cros-workon systemd coreos-go
 
 if [[ "${PV}" == 9999 ]]; then

--- a/app-admin/mayday/mayday-9999.ebuild
+++ b/app-admin/mayday/mayday-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/mayday"
+CROS_WORKON_PROJECT="flatcar/mayday"
 CROS_WORKON_LOCALNAME="mayday"
 CROS_WORKON_REPO="https://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/mayday"

--- a/app-admin/toolbox/toolbox-9999.ebuild
+++ b/app-admin/toolbox/toolbox-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/toolbox"
+CROS_WORKON_PROJECT="flatcar/toolbox"
 CROS_WORKON_LOCALNAME="toolbox"
 CROS_WORKON_REPO="https://github.com"
 
@@ -16,7 +16,7 @@ fi
 inherit cros-workon
 
 DESCRIPTION="toolbox"
-HOMEPAGE="https://github.com/flatcar-linux/toolbox"
+HOMEPAGE="https://github.com/flatcar/toolbox"
 SRC_URI=""
 
 LICENSE="Apache-2.0"

--- a/app-arch/torcx/torcx-9999.ebuild
+++ b/app-arch/torcx/torcx-9999.ebuild
@@ -2,10 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/torcx"
+CROS_WORKON_PROJECT="flatcar/torcx"
 CROS_WORKON_LOCALNAME="torcx"
 CROS_WORKON_REPO="https://github.com"
-COREOS_GO_PACKAGE="github.com/flatcar-linux/torcx"
+COREOS_GO_PACKAGE="github.com/flatcar/torcx"
 COREOS_GO_GO111MODULE="off"
 
 if [[ "${PV}" == 9999 ]]; then
@@ -18,7 +18,7 @@ fi
 inherit coreos-go cros-workon systemd
 
 DESCRIPTION="torcx is a boot-time addon manager for immutable systems"
-HOMEPAGE="https://github.com/flatcar-linux/torcx"
+HOMEPAGE="https://github.com/flatcar/torcx"
 LICENSE="Apache-2.0"
 SLOT="0"
 

--- a/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/coreos-cloudinit"
+CROS_WORKON_PROJECT="flatcar/coreos-cloudinit"
 CROS_WORKON_LOCALNAME="coreos-cloudinit"
 CROS_WORKON_REPO="https://github.com"
 COREOS_GO_PACKAGE="github.com/coreos/coreos-cloudinit"

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -3,7 +3,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/init"
+CROS_WORKON_PROJECT="flatcar/init"
 CROS_WORKON_LOCALNAME="init"
 CROS_WORKON_REPO="https://github.com"
 

--- a/coreos-base/emerge-gitclone/emerge-gitclone-9999.ebuild
+++ b/coreos-base/emerge-gitclone/emerge-gitclone-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/flatcar-dev-util"
+CROS_WORKON_PROJECT="flatcar/flatcar-dev-util"
 CROS_WORKON_REPO="https://github.com"
 CROS_WORKON_LOCALNAME="dev"
 CROS_WORKON_LOCALDIR="src/platform"
@@ -19,7 +19,7 @@ PYTHON_COMPAT=( python3_{6..10} )
 inherit cros-workon python-single-r1
 
 DESCRIPTION="emerge utilities for Flatcar developer images"
-HOMEPAGE="https://github.com/flatcar-linux/flatcar-dev-util/"
+HOMEPAGE="https://github.com/flatcar/flatcar-dev-util/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/coreos-base/oem-azure/files/oem-release
+++ b/coreos-base/oem-azure/files/oem-release
@@ -2,4 +2,4 @@ ID=azure
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Microsoft Azure"
 HOME_URL="https://azure.microsoft.com/"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-cloudsigma/files/cloud-config.yml
+++ b/coreos-base/oem-cloudsigma/files/cloud-config.yml
@@ -18,4 +18,4 @@ coreos:
     name: CloudSigma
     version-id: @@OEM_VERSION_ID@@
     home-url: https://www.cloudsigma.com/
-    bug-report-url: https://issues.flatcar-linux.org
+    bug-report-url: https://issues.flatcar.org

--- a/coreos-base/oem-digitalocean/files/oem-release
+++ b/coreos-base/oem-digitalocean/files/oem-release
@@ -2,4 +2,4 @@ ID=digitalocean
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="DigitalOcean"
 HOME_URL="https://www.digitalocean.com/"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-ec2-compat/files/oem-release
+++ b/coreos-base/oem-ec2-compat/files/oem-release
@@ -2,4 +2,4 @@ ID=@@OEM_ID@@
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="@@OEM_NAME@@"
 HOME_URL="@@OEM_HOME_URL@@"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-gce/files/oem-release
+++ b/coreos-base/oem-gce/files/oem-release
@@ -2,4 +2,4 @@ ID=gce
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Google Compute Engine"
 HOME_URL="https://cloud.google.com/products/compute-engine/"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-hyperv/files/oem-release
+++ b/coreos-base/oem-hyperv/files/oem-release
@@ -1,4 +1,4 @@
 ID=hyperv
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Microsoft Hyper-V"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-interoute/files/cloud-config.yml
+++ b/coreos-base/oem-interoute/files/cloud-config.yml
@@ -58,4 +58,4 @@ coreos:
       name: Interoute 
       version-id: @@OEM_VERSION_ID@@
       home-url: http://interoute.com/
-      bug-report-url: https://issues.flatcar-linux.org
+      bug-report-url: https://issues.flatcar.org

--- a/coreos-base/oem-niftycloud/files/cloud-config.yml
+++ b/coreos-base/oem-niftycloud/files/cloud-config.yml
@@ -54,4 +54,4 @@ coreos:
     name: NIFTY Cloud
     version-id: @@OEM_VERSION_ID@@
     home-url: http://cloud.nifty.com/
-    bug-report-url: https://issues.flatcar-linux.org
+    bug-report-url: https://issues.flatcar.org

--- a/coreos-base/oem-packet/files/oem-release
+++ b/coreos-base/oem-packet/files/oem-release
@@ -2,4 +2,4 @@ ID=packet
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Packet"
 HOME_URL="https://packet.net"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-qemu/files/oem-release
+++ b/coreos-base/oem-qemu/files/oem-release
@@ -2,4 +2,4 @@ ID=qemu
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="QEMU"
 HOME_URL="https://www.qemu.org/"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-rackspace-onmetal/files/cloud-config.yml
+++ b/coreos-base/oem-rackspace-onmetal/files/cloud-config.yml
@@ -39,4 +39,4 @@ coreos:
       name: Rackspace OnMetal
       version-id: @@OEM_VERSION_ID@@
       home-url: http://www.rackspace.com/
-      bug-report-url: https://issues.flatcar-linux.org
+      bug-report-url: https://issues.flatcar.org

--- a/coreos-base/oem-rackspace/files/cloud-config.yml
+++ b/coreos-base/oem-rackspace/files/cloud-config.yml
@@ -34,4 +34,4 @@ coreos:
     name: Rackspace Cloud Servers
     version-id: @@OEM_VERSION_ID@@
     home-url: https://www.rackspace.com/cloud/servers/
-    bug-report-url: https://issues.flatcar-linux.org
+    bug-report-url: https://issues.flatcar.org

--- a/coreos-base/oem-virtualbox/files/oem-release
+++ b/coreos-base/oem-virtualbox/files/oem-release
@@ -1,4 +1,4 @@
 ID=virtualbox
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="Oracle VirtualBox"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-vmware/files/oem-release
+++ b/coreos-base/oem-vmware/files/oem-release
@@ -2,4 +2,4 @@ ID=vmware
 VERSION_ID=@@OEM_VERSION_ID@@
 NAME="VMware"
 HOME_URL="https://www.vmware.com/"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/coreos-base/oem-vmware/oem-vmware-12.1.0.ebuild
+++ b/coreos-base/oem-vmware/oem-vmware-12.1.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="OEM suite for VMware"
-HOMEPAGE="https://github.com/flatcar-linux/coreos-overlay/tree/main/coreos-base"
+HOMEPAGE="https://github.com/flatcar/coreos-overlay/tree/main/coreos-base"
 SRC_URI=""
 
 LICENSE="Apache-2.0"

--- a/coreos-base/update-ssh-keys/update-ssh-keys-9999.ebuild
+++ b/coreos-base/update-ssh-keys/update-ssh-keys-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-CROS_WORKON_PROJECT="flatcar-linux/update-ssh-keys"
+CROS_WORKON_PROJECT="flatcar/update-ssh-keys"
 CROS_WORKON_LOCALNAME="update-ssh-keys"
 CROS_WORKON_REPO="https://github.com"
 
@@ -52,7 +52,7 @@ winapi-x86_64-pc-windows-gnu-0.4.0
 inherit coreos-cargo cros-workon
 
 DESCRIPTION="Utility for managing OpenSSH authorized public keys"
-HOMEPAGE="https://github.com/flatcar-linux/update-ssh-keys"
+HOMEPAGE="https://github.com/flatcar/update-ssh-keys"
 SRC_URI="$(cargo_crate_uris ${CRATES})"
 
 LICENSE="Apache-2.0"

--- a/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/coreos-base/update_engine/update_engine-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/update_engine"
+CROS_WORKON_PROJECT="flatcar/update_engine"
 CROS_WORKON_REPO="https://github.com"
 
 if [[ "${PV}" == 9999 ]]; then

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -67,7 +67,7 @@ __slsa_provenance_materials() {
     # The ebuild. Since "configSource" in "invocation" cannot have more than one (top/level) entry
     #  we add the ebuild and git repo checksum here, as a material.
     csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/HEAD")"
-    uri="git+https://github.com/flatcar-linux/${repo}.git@${csum}#${ebuild}"
+    uri="git+https://github.com/flatcar/${repo}.git@${csum}#${ebuild}"
     echo -e "      { \"uri\": \"${uri}\","
     echo -n "        \"digest\": {\"sha1\":\"${ebuildcsum}\"} }"
 
@@ -115,7 +115,7 @@ __slsa_provenance_materials() {
 
     # Patches / files shipped with the ebuild (if any)
     csum="$(cat "/mnt/host/source/src/scripts/.git/modules/sdk_container/src/third_party/${repo}/HEAD")"
-    uri="git+https://github.com/flatcar-linux/${repo}.git@${csum}#${CATEGORY}/${PN}/files"
+    uri="git+https://github.com/flatcar/${repo}.git@${csum}#${CATEGORY}/${PN}/files"
     if [ -d "${FILESDIR}" ] ; then
         for file in $(cd "$FILESDIR" && find . -type f | sed 's:^./::') ; do
             csum="$(sha1sum - <"${FILESDIR}/${file}")"
@@ -155,7 +155,7 @@ cat <<EOF
    "builder": {"id": "TODO - builder ID" },
    "invocation": {
       "configSource": {
-        "uri": "https://github.com/flatcar-linux/scripts",
+        "uri": "https://github.com/flatcar/scripts",
         "digest": {"sha1": "${scripts_hash}"}
       }
    },

--- a/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -151,7 +151,7 @@ cat <<EOF
  "_type": "https://in-toto.io/Statement/v0.1",
  "predicateType": "https://slsa.dev/provenance/v0.2",
  "predicate": {
-   "buildType": "ghcr.io/flatcar-linux/flatcar-sdk-all:${sdk_version}",
+   "buildType": "ghcr.io/flatcar/flatcar-sdk-all:${sdk_version}",
    "builder": {"id": "TODO - builder ID" },
    "invocation": {
       "configSource": {

--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/baselayout"
+CROS_WORKON_PROJECT="flatcar/baselayout"
 CROS_WORKON_LOCALNAME="baselayout"
 CROS_WORKON_REPO="https://github.com"
 

--- a/sys-apps/ignition/ignition-9999.ebuild
+++ b/sys-apps/ignition/ignition-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 CROS_WORKON_PROJECT="coreos/ignition"
 CROS_WORKON_LOCALNAME="ignition"
 CROS_WORKON_REPO="https://github.com"
-COREOS_GO_PACKAGE="github.com/flatcar-linux/ignition/v2"
+COREOS_GO_PACKAGE="github.com/flatcar/ignition/v2"
 COREOS_GO_GO111MODULE="off"
 inherit coreos-go cros-workon systemd udev
 
@@ -62,7 +62,7 @@ PATCHES=(
 
 src_compile() {
 	export GO15VENDOREXPERIMENT="1"
-	GO_LDFLAGS="-X github.com/flatcar-linux/ignition/v2/internal/version.Raw=${PV} -X github.com/flatcar-linux/ignition/v2/internal/distro.selinuxRelabel=false" || die
+	GO_LDFLAGS="-X github.com/flatcar/ignition/v2/internal/version.Raw=${PV} -X github.com/flatcar/ignition/v2/internal/distro.selinuxRelabel=false" || die
 	go_build "${COREOS_GO_PACKAGE}/internal"
 }
 

--- a/sys-apps/seismograph/seismograph-9999.ebuild
+++ b/sys-apps/seismograph/seismograph-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/seismograph"
+CROS_WORKON_PROJECT="flatcar/seismograph"
 CROS_WORKON_REPO="https://github.com"
 
 if [[ "${PV}" == 9999 ]]; then

--- a/sys-apps/systemd/CHECKLIST.md
+++ b/sys-apps/systemd/CHECKLIST.md
@@ -1,1 +1,1 @@
-- Check that the `systemd-sysext.service`'s `ConditionDirectoryNotEmpty` entries are correctly reflected in `flatcar-linux/init:systemd/system/ensure-sysext.service`
+- Check that the `systemd-sysext.service`'s `ConditionDirectoryNotEmpty` entries are correctly reflected in `flatcar/init:systemd/system/ensure-sysext.service`

--- a/sys-apps/systemd/systemd-250.3.ebuild
+++ b/sys-apps/systemd/systemd-250.3.ebuild
@@ -401,7 +401,7 @@ multilib_src_configure() {
 
 		# Flatcar: Set latest network interface naming scheme
 		# for
-		# https://github.com/flatcar-linux/Flatcar/issues/36
+		# https://github.com/flatcar/Flatcar/issues/36
 		-Ddefault-net-naming-scheme=latest
 
 		# Flatcar: Unported options, still needed?

--- a/sys-boot/grub/grub-9999.ebuild
+++ b/sys-boot/grub/grub-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-CROS_WORKON_PROJECT="flatcar-linux/grub"
+CROS_WORKON_PROJECT="flatcar/grub"
 CROS_WORKON_REPO="https://github.com"
 GRUB_AUTOGEN=1  # We start from Git, so always autogen.
 

--- a/sys-boot/shim/shim-9999.ebuild
+++ b/sys-boot/shim/shim-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/shim"
+CROS_WORKON_PROJECT="flatcar/shim"
 CROS_WORKON_REPO="https://github.com"
 
 if [[ "${PV}" == 9999 ]]; then

--- a/sys-kernel/README.md
+++ b/sys-kernel/README.md
@@ -41,7 +41,7 @@ and only installs files modules declare as required.
 # Keep kernel, kernel headers, and perf aligned
 
 When updating the kernel to a new major release please make sure to also update
-[the kernel headers](https://github.com/flatcar-linux/portage-stable/tree/main/sys-kernel/linux-headers)
+[the kernel headers](https://github.com/flatcar/portage-stable/tree/main/sys-kernel/linux-headers)
 and
-[perf](https://github.com/flatcar-linux/portage-stable/tree/main/dev-util/perf)
+[perf](https://github.com/flatcar/portage-stable/tree/main/dev-util/perf)
 to the same major version.

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/bootengine"
+CROS_WORKON_PROJECT="flatcar/bootengine"
 CROS_WORKON_LOCALNAME="bootengine"
 CROS_WORKON_OUTOFTREE_BUILD=1
 CROS_WORKON_REPO="https://github.com"

--- a/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
+++ b/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar-linux/nss-altfiles"
+CROS_WORKON_PROJECT="flatcar/nss-altfiles"
 CROS_WORKON_LOCALNAME="nss-altfiles"
 CROS_WORKON_REPO="https://github.com"
 


### PR DESCRIPTION
The "flatcar-linux" org will be renamed to "flatcar". For renames, there are no redirections in place and we have to update all links.

Left to do are the patch files. We could try to fix them manually or regenerate them (CC @tormath1)

## How to use

Fix the patch files.
Merge when org rename is done.

(The links in the changelog files are not changed, these must be fixed in the website data, not here because it would trigger them to be included in the next release)