### PR TITLE
.github: fix Go changelog and git show-ref bug

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -70,6 +70,7 @@ function checkout_branches() {
 
   if git -C "${SDK_OUTER_SRCDIR}/third_party/coreos-overlay" show-ref "remotes/origin/${TARGET_BRANCH}"; then
     echo "Target branch already exists. exit.";
+    return 1
   fi
 
   # Each submodule directory should be explicitly set from BASE_BRANCH,

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -60,6 +60,10 @@ for version_short in "${!VERSIONS[@]}"; do
 
   popd >/dev/null || exit
 
+  URL="https://go.dev/doc/devel/release#${VERSION_NEW}"
+
+  generate_update_changelog 'Go' "${VERSION_NEW}" "${URL}" 'go'
+
   generate_patches dev-lang go Go
   ((START_NUMBER++))
 done


### PR DESCRIPTION
Recently Go Github Actions started not creating changelog at all.
Add the missing code to the go-apply-patch to correctly generate changelog.

If `git show-ref` returns an error, i.e. the branch already exists, then we should not create a pull request, but simply return error.
Otherwise, the Github Actions would always try to create pull requests even when the branch still exists.

## Testing done

Done
