### PR TITLE
Profiles and environment overrides for packages refresh

### DIFF
--- a/coreos/config/env/net-misc/curl
+++ b/coreos/config/env/net-misc/curl
@@ -1,6 +1,0 @@
-# Since curl now builds static libraries, there are linking failures due to the
-# lack of -fPIC when building under src/ .  The project is actually configured
-# to use -fPIC when the compiler is wrapped by libtool, but that only happens
-# under lib/ and not src/ .
-CFLAGS="${CFLAGS} -fPIC"
-CXXFLAGS="${CXXFLAGS} -fPIC"

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -46,7 +46,7 @@
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
 
 # Required for CVE-2022-29187
-=dev-vcs/git-2.37.1 ~amd64 ~arm64
+=dev-vcs/git-2.37.3 ~amd64 ~arm64
 
 =sys-power/acpid-2.0.33 ~amd64 ~arm64
 

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -57,6 +57,3 @@
 
 # Required for CVE-2022-27239, CVE-2022-29869
 =net-fs/cifs-utils-6.15 ~amd64 ~arm64
-
-# Required to fix toolchains build during fsscript in stage 4 of SDK build.
-=sys-devel/crossdev-20220709 ~amd64 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -54,6 +54,3 @@
 =sys-libs/liburing-2.1-r2 ~amd64 ~arm64
 
 =app-crypt/adcli-0.9.1-r2 ~amd64 ~arm64
-
-# Required for CVE-2022-27239, CVE-2022-29869
-=net-fs/cifs-utils-6.15 ~amd64 ~arm64

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -11,4 +11,4 @@
 
 # Overwrite portage-stable mask - we want to use this version of git
 # for security fixes.
-=dev-vcs/git-2.37.1
+=dev-vcs/git-2.37.3


### PR DESCRIPTION
CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/306/

Needs to be merged together with https://github.com/flatcar/portage-stable/pull/366.
