### PR TITLE
sys-kernel/coreos-module: use strip-debug instead of strip-unneeded

### DIFF
--- a/changelog/changes/2022-09-30-kernel-strip.md
+++ b/changelog/changes/2022-09-30-kernel-strip.md
@@ -1,0 +1,1 @@
+- Switched from `--strip-unneeded` to `--strip-debug` when installing kernel modules, which makes kernel stacktraces more accurate and makes debugging issues easier ([coreos-overlay#2196](https://github.com/flatcar/coreos-overlay/pull/2196))

--- a/sys-kernel/coreos-modules/coreos-modules-5.15.70.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-5.15.70.ebuild
@@ -38,7 +38,7 @@ src_install() {
 	# The linux-firmware package will be used instead.
 	# Stripping must be done here, not portage, to preserve sigs.
 	kmake INSTALL_MOD_PATH="${D}/usr" \
-		  INSTALL_MOD_STRIP="--strip-unneeded" \
+		  INSTALL_MOD_STRIP="--strip-debug" \
 		  INSTALL_FW_PATH="${T}/fw" \
 		  modules_install
 


### PR DESCRIPTION
# sys-kernel/coreos-module: use strip-debug instead of strip-unneeded

With `--strip-unneeded` some static symbols are also stripped from modules, making stacktraces incomplete, and making it harder to debug kernel issues. Switch to the default setting of `--strip-debug`, which keeps symbols intact and does not appear to lead to a measurable size increase of the /usr partition.

## How to use

`emerge-amd64-usr coreos-modules coreos-kernel`

## Testing done

Booted image and checked:
```
$ grep kjournald /proc/kallsyms
0000000000000000 t kjournald2   [jbd2]
```

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
