### PR TITLE
profile/coreos/arm64: switch parent profile to 17.0/hardened

### DIFF
--- a/profiles/coreos/arm64/parent
+++ b/profiles/coreos/arm64/parent
@@ -1,3 +1,2 @@
-#portage-stable:hardened/linux/arm64 -- switch when available
-portage-stable:default/linux/arm64
+portage-stable:default/linux/arm64/17.0/hardened
 :coreos/base


### PR DESCRIPTION
# profile/coreos/arm64: switch parent profile to 17.0/hardened

This solves several USE flag mismatches between arm64 and amd64 images. Most important changes are bzip2 and acl support in several packages, as well as hardening in GCC.

Exact impact will be determined through CI.

## How to use

Rebuild board.

## Testing done

Needs a CI run.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
