### PR TITLE
changelog: Add an entry for go 1.18.7 update

### DIFF
--- a/changelog/updates/2022-10-10-go-update.md
+++ b/changelog/updates/2022-10-10-go-update.md
@@ -1,0 +1,1 @@
+- go ([CVE-2022-41715](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41715), [CVE-2022-2880](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2880), [CVE-2022-2879](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2879))


### PR DESCRIPTION
Merged #2208, but forgot to add the security changelog.