### PR TITLE
motd: Update the motd to notify about the deprecating LTS-2021

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="a2690c148503e9c6ac7ad6adff56830b387a0360" # flatcar-lts-2605-backport
+	CROS_WORKON_COMMIT="060724c58dcbdef4e815bde24e499c53d0df85f0" # flatcar-lts-2605-backport
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
# motd: Update the motd to notify about the deprecating LTS-2021

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>

## Testing done

Jenkins CI Running. http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/327/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.