### PR TITLE
github: Modernize the actions a bit

### DIFF
--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -48,5 +48,5 @@ generate_patches app-emulation containerd Containerd
 
 apply_patches
 
-echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
-echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"
+echo "VERSION_OLD=${VERSION_OLD}" >>"${GITHUB_OUTPUT}"
+echo "UPDATE_NEEDED=${UPDATE_NEEDED}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/containerd-releases-main.yml
+++ b/.github/workflows/containerd-releases-main.yml
@@ -18,9 +18,9 @@ jobs:
           versionMain=$(git -C containerd ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/v[0-9]*\.[0-9]*\.[0-9]*$/s/^refs\/tags\/v//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -n1)
           commitMain=$(git -C containerd rev-parse v${versionMain})
           rm -rf containerd
-          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
-          echo ::set-output name=COMMIT_MAIN::$(echo ${commitMain})
-          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo "VERSION_MAIN=${versionMain}" >>"${GITHUB_OUTPUT}"
+          echo "COMMIT_MAIN=${commitMain}" >>"${GITHUB_OUTPUT}"
+          echo "BASE_BRANCH_MAIN=main" >>"${GITHUB_OUTPUT}"
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
         run: .github/workflows/setup-flatcar-sdk.sh

--- a/.github/workflows/containerd-releases-main.yml
+++ b/.github/workflows/containerd-releases-main.yml
@@ -8,7 +8,7 @@ jobs:
   get-containerd-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch latest Containerd release
@@ -36,7 +36,7 @@ jobs:
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/containerd-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -60,5 +60,5 @@ generate_patches app-emulation docker Docker app-emulation/docker-cli app-torcx/
 
 apply_patches
 
-echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
-echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"
+echo "VERSION_OLD=${VERSION_OLD}" >>"${GITHUB_OUTPUT}"
+echo "UPDATE_NEEDED=${UPDATE_NEEDED}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/docker-releases-main.yml
+++ b/.github/workflows/docker-releases-main.yml
@@ -20,10 +20,10 @@ jobs:
           commitMain=$(git -C docker rev-parse --short=10 v${versionMain})
           commitCli=$(git -C docker-cli rev-parse --short=10 v${versionMain})
           rm -rf docker docker-cli
-          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
-          echo ::set-output name=COMMIT_MAIN::$(echo ${commitMain})
-          echo ::set-output name=COMMIT_CLI::$(echo ${commitCli})
-          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo "VERSION_MAIN=${versionMain}" >>"${GITHUB_OUTPUT}"
+          echo "COMMIT_MAIN=${commitMain}" >>"${GITHUB_OUTPUT}"
+          echo "COMMIT_CLI=${commitCli}" >>"${GITHUB_OUTPUT}"
+          echo "BASE_BRANCH_MAIN=main" >>"${GITHUB_OUTPUT}"
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
         run: .github/workflows/setup-flatcar-sdk.sh

--- a/.github/workflows/docker-releases-main.yml
+++ b/.github/workflows/docker-releases-main.yml
@@ -8,7 +8,7 @@ jobs:
   get-docker-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch latest Docker release
@@ -40,7 +40,7 @@ jobs:
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/docker-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -36,5 +36,5 @@ generate_patches sys-kernel coreos-firmware "Linux Firmware"
 
 apply_patches
 
-echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
-echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"
+echo "VERSION_OLD=${VERSION_OLD}" >>"${GITHUB_OUTPUT}"
+echo "UPDATE_NEEDED=${UPDATE_NEEDED}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/firmware-releases-main.yml
+++ b/.github/workflows/firmware-releases-main.yml
@@ -17,8 +17,8 @@ jobs:
           git clone --depth=1 --no-checkout https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
           versionMain=$(git -C linux-firmware ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
           rm -rf linux-firmware
-          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
-          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo "VERSION_MAIN=${versionMain}" >>"${GITHUB_OUTPUT}"
+          echo "BASE_BRANCH_MAIN=main" >>"${GITHUB_OUTPUT}"
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
         run: .github/workflows/setup-flatcar-sdk.sh

--- a/.github/workflows/firmware-releases-main.yml
+++ b/.github/workflows/firmware-releases-main.yml
@@ -8,7 +8,7 @@ jobs:
   get-firmware-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch latest Linux Firmware release
@@ -33,7 +33,7 @@ jobs:
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/firmware-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -76,7 +76,7 @@ apply_patches
 vo_gh="$(join_by ' and ' "${UPDATED_VERSIONS_OLD[@]}")"
 vn_gh="$(join_by ' and ' "${UPDATED_VERSIONS_NEW[@]}")"
 
-echo ::set-output name=VERSIONS_OLD::"${vo_gh}"
-echo ::set-output name=VERSIONS_NEW::"${vn_gh}"
-echo ::set-output name=BRANCH_NAME::"${branch_name}"
-echo ::set-output name=UPDATE_NEEDED::"1"
+echo "VERSIONS_OLD=${vo_gh}" >>"${GITHUB_OUTPUT}"
+echo "VERSIONS_NEW=${vn_gh}" >>"${GITHUB_OUTPUT}"
+echo "BRANCH_NAME=${branch_name}" >>"${GITHUB_OUTPUT}"
+echo "UPDATE_NEEDED=1" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/go-releases-main.yml
+++ b/.github/workflows/go-releases-main.yml
@@ -8,7 +8,7 @@ jobs:
   get-go-releases:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch latest Go releases
@@ -38,7 +38,7 @@ jobs:
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/go-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-releases-main.yml
+++ b/.github/workflows/go-releases-main.yml
@@ -22,8 +22,8 @@ jobs:
             versionsMain+=($(git -C go ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/go${goversion}\(\.[0-9]*\)\?$/s/^refs\/tags\/go//p" | egrep -v -e '(beta|rc)' | sort -ruV | head -1))
           done
           rm -rf go
-          echo ::set-output name=VERSIONS_MAIN::$(echo ${versionsMain[*]})
-          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo "VERSIONS_MAIN=${versionsMain[*]}" >>"${GITHUB_OUTPUT}"
+          echo "BASE_BRANCH_MAIN=main" >>"${GITHUB_OUTPUT}"
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
         run: .github/workflows/setup-flatcar-sdk.sh

--- a/.github/workflows/mirror-calico.yml
+++ b/.github/workflows/mirror-calico.yml
@@ -9,7 +9,7 @@ jobs:
   mirror-calico:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Login to GitHub Container Registry (ghcr)
         run: echo ${{ secrets.GHCR_PASSWORD }} | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
       - name: Fetch latest Calico release

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -57,5 +57,5 @@ generate_patches app-emulation docker-runc Runc
 
 apply_patches
 
-echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
-echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"
+echo "VERSION_OLD=${VERSION_OLD}" >>"${GITHUB_OUTPUT}"
+echo "UPDATE_NEEDED=${UPDATE_NEEDED}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/runc-releases-main.yml
+++ b/.github/workflows/runc-releases-main.yml
@@ -22,9 +22,9 @@ jobs:
           commitMain="$(git -C runc rev-parse v${versionMain})"
           versionMain="${versionMain//-/_}"
           rm -rf runc
-          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
-          echo ::set-output name=COMMIT_MAIN::$(echo ${commitMain})
-          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo "VERSION_MAIN=${versionMain}" >>"${GITHUB_OUTPUT}"
+          echo "COMMIT_MAIN=${commitMain}" >>"${GITHUB_OUTPUT}"
+          echo "BASE_BRANCH_MAIN=main" >>"${GITHUB_OUTPUT}"
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
         run: .github/workflows/setup-flatcar-sdk.sh

--- a/.github/workflows/runc-releases-main.yml
+++ b/.github/workflows/runc-releases-main.yml
@@ -8,7 +8,7 @@ jobs:
   get-runc-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch latest Runc release
@@ -40,7 +40,7 @@ jobs:
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/runc-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -42,5 +42,5 @@ generate_patches dev-lang rust dev-lang/rust profiles
 
 apply_patches
 
-echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
-echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"
+echo "VERSION_OLD=${VERSION_OLD}" >>"${GITHUB_OUTPUT}"
+echo "UPDATE_NEEDED=${UPDATE_NEEDED}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/rust-release-main.yml
+++ b/.github/workflows/rust-release-main.yml
@@ -8,7 +8,7 @@ jobs:
   get-rust-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch latest Rust release
@@ -34,7 +34,7 @@ jobs:
         run: .github/workflows/rust-apply-patch.sh
       - name: Create pull request for main
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-release-main.yml
+++ b/.github/workflows/rust-release-main.yml
@@ -17,8 +17,8 @@ jobs:
           git clone --depth=1 --no-checkout https://github.com/rust-lang/rust
           versionMain=$(git -C rust ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/1\.[0-9]*\.[0-9]*$/s/^refs\/tags\///p" | sort -ruV | head -n1)
           rm -rf rust
-          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
-          echo ::set-output name=BASE_BRANCH_MAIN::main
+          echo "VERSION_MAIN=${versionMain}" >>"${GITHUB_OUTPUT}"
+          echo "BASE_BRANCH_MAIN=main" >>"${GITHUB_OUTPUT}"
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
         run: .github/workflows/setup-flatcar-sdk.sh

--- a/.github/workflows/setup-flatcar-sdk.sh
+++ b/.github/workflows/setup-flatcar-sdk.sh
@@ -47,6 +47,6 @@ export PACKAGES_CONTAINER="flatcar-packages-${arch}-${docker_vernum}"
 
 popd || exit
 
-echo ::set-output name=path::"${PATH}"
-echo ::set-output name=PACKAGES_CONTAINER::"${PACKAGES_CONTAINER}"
-echo ::set-output name=SDK_NAME::"${SDK_NAME}"
+echo "path=${PATH}" >>"${GITHUB_OUTPUT}"
+echo "PACKAGES_CONTAINER=${PACKAGES_CONTAINER}" >>"${GITHUB_OUTPUT}"
+echo "SDK_NAME=${SDK_NAME}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/vmware-apply-patch.sh
+++ b/.github/workflows/vmware-apply-patch.sh
@@ -45,5 +45,5 @@ generate_patches app-emulation open-vm-tools open-vm-tools coreos-base/oem-vmwar
 
 apply_patches
 
-echo ::set-output name=VERSION_OLD::"${VERSION_OLD}"
-echo ::set-output name=UPDATE_NEEDED::"${UPDATE_NEEDED}"
+echo "VERSION_OLD=${VERSION_OLD}" >>"${GITHUB_OUTPUT}"
+echo "UPDATE_NEEDED=${UPDATE_NEEDED}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/vmware-releases-main.yml
+++ b/.github/workflows/vmware-releases-main.yml
@@ -8,7 +8,7 @@ jobs:
   get-vmware-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch latest open-vm-tools release
@@ -36,7 +36,7 @@ jobs:
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
         run: .github/workflows/vmware-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vmware-releases-main.yml
+++ b/.github/workflows/vmware-releases-main.yml
@@ -18,9 +18,9 @@ jobs:
           versionMain=$(git -C open-vm-tools ls-remote --tags origin | cut -f2 | sed -n "/refs\/tags\/stable-[0-9]*\.[0-9]*\.[0-9]*$/s/^refs\/tags\/stable-//p" | sort -ruV | head -n1)
           buildNumber=$(curl -sSL https://api.github.com/repos/vmware/open-vm-tools/releases/latest | jq -r '.assets[0].name' | sed -n "s/^open-vm-tools-${versionMain}*-\([0-9]*\)\..*/\1/p")
           rm -rf open-vm-tools
-          echo ::set-output name=BASE_BRANCH_MAIN::main
-          echo ::set-output name=BUILD_NUMBER::$(echo ${buildNumber})
-          echo ::set-output name=VERSION_MAIN::$(echo ${versionMain})
+          echo "BASE_BRANCH_MAIN=main" >>"${GITHUB_OUTPUT}"
+          echo "BUILD_NUMBER=${buildNumber}" >>"${GITHUB_OUTPUT}"
+          echo "VERSION_MAIN=${versionMain}" >>"${GITHUB_OUTPUT}"
       - name: Set up Flatcar SDK
         id: setup-flatcar-sdk
         run: .github/workflows/setup-flatcar-sdk.sh


### PR DESCRIPTION
Basically bump versions of the actions we use and use a recommended way of setting output. This is to avoid usage of the deprecated features (node 12 and the set-output stuff).

The node 12 deprecation: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

The set-output command deprecation: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/