### PR TITLE
Profile changes for the weekly updates

### DIFF
--- a/profiles/coreos/amd64/sdk/package.accept_keywords
+++ b/profiles/coreos/amd64/sdk/package.accept_keywords
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 Flatcar Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# It's stable for arm64, so make it available on amd64 SDK too.
+=dev-util/cmake-3.24.2 ~amd64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -39,9 +39,6 @@
 # FIPS support is still being tested
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
 
-# Required for CVE-2022-29187
-=dev-vcs/git-2.37.3 ~amd64 ~arm64
-
 =sys-power/acpid-2.0.33 ~amd64 ~arm64
 
 # Overwrite portage-stable mask - use latest liburing -r2 for ARM64 and AMD64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -2,6 +2,9 @@
 # Copyright (c) 2013 The CoreOS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
+# Required for addressing some CVEs
+=dev-libs/libxml2-2.10.3 ~amd64 ~arm64
+
 =app-arch/zstd-1.4.9 ~amd64 ~arm64
 
 =app-emulation/qemu-7.0.0-r1 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -30,6 +30,9 @@
 
 =sys-libs/libseccomp-2.5.0 ~amd64 ~arm64
 
+# Initially for CVE-2022-37434, but the backport already fixed it.
+=sys-libs/zlib-1.2.13 ~amd64 ~arm64
+
 # Keep headers in sync with kernel version.
 =sys-kernel/linux-headers-5.15 ~amd64 ~arm64
 


### PR DESCRIPTION
- Adds accept keywords for libxml2, zlib and cmake.
- Drops accept keywords for git.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/337/cldsv

This is for https://github.com/flatcar/portage-stable/pull/371.

For changelog and differences, see portage-stable PR.
