### PR TITLE
profiles: Accept keywords for curl 7.85

### DIFF
--- a/changelog/security/2022-10-20-curl-update.md
+++ b/changelog/security/2022-10-20-curl-update.md
@@ -1,0 +1,1 @@
+- curl ([CVE-2022-35252](https://nvd.nist.gov/vuln/detail/CVE-2022-35252))

--- a/changelog/updates/2022-10-20-curl-update.md
+++ b/changelog/updates/2022-10-20-curl-update.md
@@ -1,0 +1,1 @@
+- curl ([7.85](https://curl.se/mail/archive-2022-08/0012.html))

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -14,6 +14,9 @@
 
 =dev-libs/libgcrypt-1.9.4 ~amd64 ~arm64
 
+# To address CVE-2022-35252.
+=net-misc/curl-7.85.0-r2 ~amd64 ~arm64
+
 =net-misc/openssh-8.8_p1-r3 ~amd64 ~arm64
 
 # Required for addressing CVE-2022-29154

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -10,8 +10,7 @@ dev-libs/libxml2	-python
 dev-libs/libxslt	-python
 dev-util/perf		-doc
 dev-vcs/git		webdav curl bash-completion
-# We don't want any driver/hw rendering on the host
-net-misc/curl		kerberos threads telnet
+net-misc/curl		kerberos telnet
 net-misc/iputils	arping tracepath traceroute6
 sys-devel/gettext	-git
 


### PR DESCRIPTION
CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/339/cldsv

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

Nothing stands out: [amd64](http://jenkins.infra.kinvolk.io:8080/job/container/job/image_changes/364/console), [arm64](http://jenkins.infra.kinvolk.io:8080/job/container/job/image_changes/363/console)