### PR TITLE
coreos-base/oem-ec2-compat: pull ssh keys from metadata server

### DIFF
--- a/changelog/changes/2022-10-19-openstack-metadata.md
+++ b/changelog/changes/2022-10-19-openstack-metadata.md
@@ -1,0 +1,1 @@
+- OpenStack: enabled `coreos-metadata-sshkeys@.service` to provision SSH keys from metadata. ([Flatcar#817](https://github.com/flatcar/Flatcar/issues/817), [coreos-overlay#2246](https://github.com/flatcar/coreos-overlay/pull/2246))

--- a/coreos-base/oem-ec2-compat/files/base/openstack.ign
+++ b/coreos-base/oem-ec2-compat/files/base/openstack.ign
@@ -1,0 +1,13 @@
+{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "systemd": {
+    "units": [
+      {
+        "enabled": true,
+        "name": "coreos-metadata-sshkeys@.service"
+      }
+    ]
+  }
+}

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2-r2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.1.2-r2.ebuild
@@ -63,4 +63,8 @@ src_install() {
 	if use ec2 ; then
 		newins "${FILESDIR}/base/base-ec2.ign" base.ign
 	fi
+
+	if use openstack; then
+		newins "${FILESDIR}/base/openstack.ign" base.ign
+	fi
 }


### PR DESCRIPTION
In this PR, we're enabling the `coreos-metadata-sshkeys@.service` for the OpenStack image in order to pull SSH keys from the OpenStack metadata server if no user configuration is provided.

## How to use

Boot an instance on OpenStack without Ignition provided SSH keys. 

## Testing done

Manually tested with https://github.com/flatcar/mantle/pull/388

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/585/cldsv/ 

<hr>

Should fix: https://github.com/flatcar/Flatcar/issues/817
