### PR TITLE
app-admin/toolbox: Use containerd

### DIFF
--- a/app-admin/toolbox/toolbox-9999.ebuild
+++ b/app-admin/toolbox/toolbox-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="a851cb8961f092012e4d64ba1e71b27b36b7ec9d" # flatcar-master
+	CROS_WORKON_COMMIT="9695c9b42036ac958fae10a6268f95ae5c3fcc2b" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/changelog/changes/2022-10-27-toolbox.md
+++ b/changelog/changes/2022-10-27-toolbox.md
@@ -1,0 +1,1 @@
+- Toolbox now uses containerd to download and mount the image ([toolbox#7](https://github.com/flatcar/toolbox/pull/7))


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/toolbox/pull/7
to download and mount the image with containerd instead of requiring Docker.

## How to use


## Testing done

Tested manually

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
