### PR TITLE
profiles: accept keywords for multipath-tools 0.9.3

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -42,6 +42,9 @@
 # Keep iproute in sync with kernel version.
 =sys-apps/iproute2-5.15.0 ~amd64 ~arm64
 
+# To address CVE-2022-41973, CVE-2022-41974
+=sys-fs/multipath-tools-0.9.3 ~amd64 ~arm64
+
 # FIPS support is still being tested
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
 


### PR DESCRIPTION
Accept keywords `~amd64`, `~arm64` for `sys-fs/multipath-tools` 0.9.3 to address [CVE-2022-41973](https://nvd.nist.gov/vuln/detail/CVE-2022-41973), [CVE-2022-41974](https://nvd.nist.gov/vuln/detail/CVE-2022-41974).

This PR should be merged together with https://github.com/flatcar/portage-stable/pull/381.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/668/cldsv/
