### PR TITLE
profiles: accept keywords for app-arch/cpio 2.13-r3

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -2,6 +2,9 @@
 # Copyright (c) 2013 The CoreOS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
+# To address CVE-2021-38185
+=app-arch/cpio-2.13-r3 ~amd64 ~arm64
+
 =app-arch/zstd-1.4.9 ~amd64 ~arm64
 
 =app-emulation/qemu-7.0.0-r1 ~arm64


### PR DESCRIPTION
Accept keywords for `app-arch/cpio` 2.13-r3, mainly to address [CVE-2021-38185](https://nvd.nist.gov/vuln/detail/CVE-2021-38185).

This PR should be merged together with https://github.com/flatcar/portage-stable/pull/390.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/415/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. (not needed)
