### PR TITLE
profiles: Drop accept keywords for app-arch/libarchive

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -1,8 +1,6 @@
 # arm64 keywords
 # Keep these in alphabetical order.
 
-=app-arch/libarchive-3.6.1 ~arm64
-
 # needed by arm64-native SDK
 =app-emulation/open-vmdk-1.0 *
 =app-crypt/rhash-1.4.2 ~arm64


### PR DESCRIPTION
Should be merged together with https://github.com/flatcar/portage-stable/pull/397.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/444/cldsv

The updated package is stable for both amd64 and arm64.
