### PR TITLE
sys-kernel/bootengine: Always run initrd-setup-root

### DIFF
--- a/changelog/bugfixes/2022-01-09-initrd-setup-root.md
+++ b/changelog/bugfixes/2022-01-09-initrd-setup-root.md
@@ -1,0 +1,1 @@
+- The rootfs setup in the initrd now runs systemd-tmpfiles on every boot, not only when Ignition runs, to fix a dbus failure due to missing files ([Flatcar#944](https://github.com/flatcar/Flatcar/issues/944))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="95bb406972f1846945e8e355ab98cafa570f273f" # flatcar-master
+	CROS_WORKON_COMMIT="bda2db88381eab5a572a50c0eaae747906a7005c" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
c8399e42bb9651c3c108f916f6645557ab41884b which is a backport of the relevant parts of https://github.com/flatcar/bootengine/pull/50 to fix https://github.com/flatcar/Flatcar/issues/944

## How to use

This should also be picked for Beta 3432 and Alpha 3446 (and any newly branched Alpha if merged afterwards).

## Testing done

[here](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1025/cldsv/)
and with `./flatcar_production_pxe.sh  -append 'flatcar.autologin'`

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
