### PR TITLE
sys-kernel/bootengine: Manage systemd-sysext images for A/B booting

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="bda2db88381eab5a572a50c0eaae747906a7005c" # flatcar-master
+	CROS_WORKON_COMMIT="d362a47d14612edb584f9d122cb883650a7bb6b8" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 
@@ -38,5 +38,6 @@ src_install() {
 		"${D}"/usr/lib/dracut/modules.d/30ignition/retry-umount.sh \
 		"${D}"/usr/lib/dracut/modules.d/35torcx/torcx-profile-populate-generator \
 		"${D}"/usr/lib/dracut/modules.d/99setup-root/initrd-setup-root \
+		"${D}"/usr/lib/dracut/modules.d/99setup-root/initrd-setup-root-after-ignition \
 		|| die chmod
 }


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/bootengine/pull/50
to select the active sysext images for OEMs or Flatcar extensions that are coupled to the OS version. Systemd 252 is needed for the sysext images to load without error because earlier systemd versions were too strict about the final filename target name of a symlink.

## How to use

Update git ref to bootengine repo merge commit before merging

## Testing done

See linked PR

I don't think we need a changelog because this is not yet resulting in a change for the user.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
