### PR TITLE
coreos: Add patches for gentoolkit, portage-utils and gcc-config

### DIFF
--- a/coreos/user-patches/app-portage/gentoolkit/0001-profile-Default-to-main-repo-name.patch
+++ b/coreos/user-patches/app-portage/gentoolkit/0001-profile-Default-to-main-repo-name.patch
@@ -1,0 +1,53 @@
+From e40cd8c76bee4f7c108c1066d60aaf5d8c3adede Mon Sep 17 00:00:00 2001
+From: Krzesimir Nowak <knowak@microsoft.com>
+Date: Thu, 8 Dec 2022 16:25:39 +0100
+Subject: [PATCH] profile: Default to main repo name
+
+In Flatcar we have a different repo marked as a default one
+(portage-stable), so "equery keywords" was crashing because it was
+trying to use gentoo repo anyways.
+
+Signed-off-by: Krzesimir Nowak <knowak@microsoft.com>
+Closes: https://github.com/gentoo/gentoolkit/pull/24
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ pym/gentoolkit/profile.py | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/pym/gentoolkit/profile.py b/pym/gentoolkit/profile.py
+index dcd02cc..c880137 100644
+--- a/pym/gentoolkit/profile.py
++++ b/pym/gentoolkit/profile.py
+@@ -23,19 +23,26 @@ def warning(msg):
+ 	print('warning: %s' % msg, file=sys.stderr)
+ 
+ 
+-def load_profile_data(portdir=None, repo='gentoo'):
++def load_profile_data(portdir=None, repo=''):
+ 	"""Load the list of known arches from the tree
+ 
+ 	Args:
+ 	  portdir: The repository to load all data from (and ignore |repo|)
+-	  repo: Look up this repository by name to locate profile data
++	  repo: Look up this repository by name to locate profile data (if empty, uses main repo name)
+ 
+ 	Returns:
+ 	  A dict mapping the keyword to its preferred state:
+ 	  {'x86': ('stable', 'arch'), 'mips': ('dev', '~arch'), ...}
+ 	"""
+ 	if portdir is None:
+-		portdir = portage.db[portage.root]['vartree'].settings.repositories[repo].location
++		repos = portage.db[portage.root]["vartree"].settings.repositories
++		if repo == "":
++			main_repo = repos.mainRepo()
++			if main_repo is None:
++				repo = "gentoo"
++			else:
++				repo = main_repo.name
++		portdir = repos[repo].location
+ 
+ 	arch_status = {}
+ 
+-- 
+2.25.1
+

--- a/coreos/user-patches/app-portage/gentoolkit/README.md
+++ b/coreos/user-patches/app-portage/gentoolkit/README.md
@@ -1,0 +1,1 @@
+Drop `0001-profile-Default-to-main-repo-name.patch` when we have gentoolkit 0.6.2 or greater.

--- a/coreos/user-patches/app-portage/portage-utils/0001-main-Print-the-ignored-parent-line-in-warning.patch
+++ b/coreos/user-patches/app-portage/portage-utils/0001-main-Print-the-ignored-parent-line-in-warning.patch
@@ -1,0 +1,29 @@
+From 9c67a37fc7709c9e314bc56ccdf7727bee02fc92 Mon Sep 17 00:00:00 2001
+From: Krzesimir Nowak <knowak@microsoft.com>
+Date: Wed, 14 Dec 2022 12:52:25 +0100
+Subject: [PATCH 1/2] main: Print the ignored parent line in warning
+
+If repo name in the parent line was empty, nothing was printed.
+
+Signed-off-by: Krzesimir Nowak <knowak@microsoft.com>
+Signed-off-by: Fabian Groffen <grobian@gentoo.org>
+---
+ main.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/main.c b/main.c
+index 809a085..f6a39f9 100644
+--- a/main.c
++++ b/main.c
+@@ -646,6 +646,8 @@ read_portage_profile(const char *profile, env_vars vars[], set *masks)
+ 					repo_name = NULL;
+ 				}
+ 				if (repo_name == NULL) {
++					/* bring back the colon to see the ignored parent line */
++					*(--p) = ':';
+ 					warn("ignoring parent with unknown repo in profile %s: %s",
+ 							profile, s);
+ 					continue;
+-- 
+2.25.1
+

--- a/coreos/user-patches/app-portage/portage-utils/0002-main-Handle-empty-repo-names-in-parent-files.patch
+++ b/coreos/user-patches/app-portage/portage-utils/0002-main-Handle-empty-repo-names-in-parent-files.patch
@@ -1,0 +1,141 @@
+From 8f7064fdf7aa08e00bb24e5e479c1df4be9ae5e7 Mon Sep 17 00:00:00 2001
+From: Krzesimir Nowak <knowak@microsoft.com>
+Date: Wed, 14 Dec 2022 12:53:33 +0100
+Subject: [PATCH 2/2] main: Handle empty repo names in parent files
+
+Empty repo name is documented in portage(5).
+
+Signed-off-by: Krzesimir Nowak <knowak@microsoft.com>
+Signed-off-by: Fabian Groffen <grobian@gentoo.org>
+---
+ main.c | 105 ++++++++++++++++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 89 insertions(+), 16 deletions(-)
+
+diff --git a/main.c b/main.c
+index f6a39f9..347a50b 100644
+--- a/main.c
++++ b/main.c
+@@ -598,6 +598,65 @@ read_portage_file(const char *file, enum portage_file_type type, void *data)
+ 		fprintf(stderr, "read profile %s\n", file);
+ }
+ 
++/* Helper to check if a string starts with a prefix. If so, returns
++ * true and gets the length of the prefix. Otherwise returns false,
++ * leaving the prefix length unmodified. */
++static bool
++starts_with(const char *str, const char *prefix, size_t *prefix_len)
++{
++	const char *s;
++	const char *p;
++	size_t len;
++
++	if (prefix == NULL) {
++		/* every string starts with a null string */
++		if (prefix_len != NULL)
++			*prefix_len = 0;
++		return true;
++	}
++	if (str == NULL)
++		/* null string only starts with a null string, and prefix isn't null */
++		return false;
++
++	len = 0;
++	for (s = str, p = prefix; *s != '\0' && *p != '\0'; ++s, ++p, ++len) {
++		if (*s != *p)
++			return false;
++	}
++	if (*p == '\0') {
++		if (prefix_len != NULL)
++			*prefix_len = len;
++		return true;
++	}
++	return false;
++}
++
++/* Helper to figure out inside of which overlay a path is. Returns
++ * null if nonesuch is found. */
++static const char *
++overlay_from_path (const char *path)
++{
++	size_t n;
++	char *overlay;
++	size_t max_match = 0;
++	const char *found_overlay = NULL;
++
++	array_for_each(overlays, n, overlay) {
++		size_t overlay_len;
++
++		if (!starts_with(path, overlay, &overlay_len))
++			continue;
++
++		if (overlay_len <= max_match)
++			continue;
++
++		max_match = overlay_len;
++		found_overlay = overlay;
++	}
++
++	return found_overlay;
++}
++
+ /* Helper to recursively read stacked make.defaults in profiles */
+ static void
+ read_portage_profile(const char *profile, env_vars vars[], set *masks)
+@@ -634,24 +693,38 @@ read_portage_profile(const char *profile, env_vars vars[], set *masks)
+ 				/* split repo from target */
+ 				*p++ = '\0';
+ 
+-				/* match the repo */
+-				repo_name = NULL;
+-				array_for_each(overlays, n, overlay) {
+-					repo_name = xarrayget(overlay_names, n);
+-					if (strcmp(repo_name, s) == 0) {
+-						snprintf(profile_file, sizeof(profile_file),
+-								"%s/profiles/%s/", overlay, p);
+-						break;
++				if (s[0] == '\0') {
++					/* empty repo name means a repo where the profile is */
++					const char* current_overlay = overlay_from_path (profile);
++					if (current_overlay == NULL) {
++						/* bring back the colon to see the ignored parent line */
++						*(--p) = ':';
++						warn("could not figure out current repo of profile %s, ignoring parent %s",
++							       profile, s);
++						continue;
+ 					}
++					snprintf(profile_file, sizeof(profile_file),
++							"%s/profiles/%s", current_overlay, p);
++				} else {
++					/* match the repo */
+ 					repo_name = NULL;
+-				}
+-				if (repo_name == NULL) {
+-					/* bring back the colon to see the ignored parent line */
+-					*(--p) = ':';
+-					warn("ignoring parent with unknown repo in profile %s: %s",
+-							profile, s);
+-					continue;
+-				}
++					array_for_each(overlays, n, overlay) {
++						repo_name = xarrayget(overlay_names, n);
++						if (strcmp(repo_name, s) == 0) {
++							snprintf(profile_file, sizeof(profile_file),
++									"%s/profiles/%s/", overlay, p);
++							break;
++						}
++						repo_name = NULL;
++					}
++					if (repo_name == NULL) {
++						/* bring back the colon to see the ignored parent line */
++						*(--p) = ':';
++						warn("ignoring parent with unknown repo in profile %s: %s",
++								profile, s);
++						continue;
++					}
++                                }
+ 			} else {
+ 				snprintf(profile_file + profile_len,
+ 						sizeof(profile_file) - profile_len, "%s", s);
+-- 
+2.25.1
+

--- a/coreos/user-patches/app-portage/portage-utils/README.md
+++ b/coreos/user-patches/app-portage/portage-utils/README.md
@@ -1,0 +1,1 @@
+Drop `0001-main-Print-the-ignored-parent-line-in-warning.patch` and `0002-main-Handle-empty-repo-names-in-parent-files.patch` when we have portage-utils 0.94.5 or greater.

--- a/coreos/user-patches/sys-devel/gcc-config/0001-gcc-config-Use-relative-paths-for-liblto-and-cc-syml.patch
+++ b/coreos/user-patches/sys-devel/gcc-config/0001-gcc-config-Use-relative-paths-for-liblto-and-cc-syml.patch
@@ -1,0 +1,47 @@
+From d245197378818f66c978d4427b6d0d81fbfaefc6 Mon Sep 17 00:00:00 2001
+From: Krzesimir Nowak <knowak@microsoft.com>
+Date: Thu, 10 Nov 2022 16:45:48 +0100
+Subject: [PATCH] gcc-config: Use relative paths for liblto and cc symlink
+ targets
+
+That way, for ROOT different than / (like /build/amd64-usr) these
+symlinks won't dangle after chrooting into ROOT.
+
+Bug: https://bugs.gentoo.org/880977
+Signed-off-by: Krzesimir Nowak <knowak@microsoft.com>
+Closes: https://github.com/gentoo/gcc-config/pull/2
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ gcc-config | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/gcc-config b/gcc-config
+index a44fced..f39dd5c 100755
+--- a/gcc-config
++++ b/gcc-config
+@@ -345,7 +345,7 @@ update_wrappers() {
+ 	# But create our own ${CTARGET}-cc in /usr/bin to avoid fallbacks
+ 	# to the symlinks LLVM creates (sys-devel/clang-toolchain-symlinks).
+ 	# bug #872416.
+-	atomic_ln "${EROOT}usr/bin/${CTARGET}-gcc" "${EROOT}usr/bin" "${CTARGET}-cc"
++	atomic_ln "${CTARGET}-gcc" "${EROOT}usr/bin" "${CTARGET}-cc"
+ 
+ 	# handle the canonical cpp wrapper
+ 	if ! is_cross_compiler ; then
+@@ -813,11 +813,12 @@ switch_profile() {
+ 	# Update LTO plugin for GCC.  Supported as of binutils 2.25.
+ 	local BFD_PLUGINS_DIR
+ 	local LIBLTO_PLUGIN
+-	LIBLTO_PLUGIN="${EROOT}usr/libexec/gcc/${CTARGET}/${CC_COMP_VERSION}/liblto_plugin.so"
+ 	if is_cross_compiler; then
+ 		BFD_PLUGINS_DIR="${EROOT}usr/${CHOST}/${CTARGET}/binutils-bin/lib/bfd-plugins"
++		LIBLTO_PLUGIN="../../../../../libexec/gcc/${CTARGET}/${CC_COMP_VERSION}/liblto_plugin.so"
+ 	else
+ 		BFD_PLUGINS_DIR="${EROOT}usr/${CHOST}/binutils-bin/lib/bfd-plugins"
++	        LIBLTO_PLUGIN="../../../../libexec/gcc/${CTARGET}/${CC_COMP_VERSION}/liblto_plugin.so"
+ 	fi
+ 	mkdir -p "${BFD_PLUGINS_DIR}"
+ 	ln -sf "${LIBLTO_PLUGIN}" "${BFD_PLUGINS_DIR}"
+-- 
+2.25.1
+

--- a/coreos/user-patches/sys-devel/gcc-config/README.md
+++ b/coreos/user-patches/sys-devel/gcc-config/README.md
@@ -1,0 +1,1 @@
+Drop `0001-gcc-config-Use-relative-paths-for-liblto-and-cc-syml.patch` when we have gcc-config 2.10 or greater.


### PR DESCRIPTION
Patches for gentoolkit and portage-utils will be useful for my package automation work, gcc-config patch is a fix that renders a hack in scripts repo as unnecessary.

Should be merged together with https://github.com/flatcar/scripts/pull/626.

CI passed: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/525/cldsv/