### PR TITLE
profiles: accept keywords ~arm64 for dev-vcs/git 2.37.5 for flatcar-3374

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -20,6 +20,9 @@
 # needed by arm64-native SDK
 =dev-util/checkbashisms-2.21.4 ~arm64
 
+# needed to address CVE-2022-23521, CVE-2022-41903
+=dev-vcs/git-2.37.5 ~arm64
+
 =net-dns/c-ares-1.17.2 ~arm64
 =net-firewall/conntrack-tools-1.4.6-r1 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -49,9 +49,6 @@
 # FIPS support is still being tested
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
 
-# Required for CVE-2022-29187
-=dev-vcs/git-2.37.3 ~amd64 ~arm64
-
 =sys-power/acpid-2.0.33 ~amd64 ~arm64
 
 # Overwrite portage-stable mask - use latest liburing -r2 for ARM64 and AMD64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -50,7 +50,7 @@
 =sys-fs/cryptsetup-2.4.3-r1 ~amd64 ~arm64
 
 # Required for CVE-2022-29187
-=dev-vcs/git-2.37.1 ~amd64 ~arm64
+=dev-vcs/git-2.37.3 ~amd64 ~arm64
 
 =sys-power/acpid-2.0.33 ~amd64 ~arm64
 

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -11,4 +11,4 @@
 
 # Overwrite portage-stable mask - we want to use this version of git
 # for security fixes.
-=dev-vcs/git-2.37.1
+=dev-vcs/git-2.37.3

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -11,4 +11,4 @@
 
 # Overwrite portage-stable mask - we want to use this version of git
 # for security fixes.
-=dev-vcs/git-2.37.3
+=dev-vcs/git-2.37.5


### PR DESCRIPTION
Accept keywords `~arm64` for `dev-vcs/git` 2.37.5, mainly to address [CVE-2022-23521](https://nvd.nist.gov/vuln/detail/CVE-2022-23521), [CVE-2022-41903](https://nvd.nist.gov/vuln/detail/CVE-2022-41903).

Cherry-picking the following required commits:
* bb17d534d8cbd2f9687651cca2eac6f8d055fe86
* e4d888f18481eda3b12fb72a087774876ca0647a
* ede544c96380581390fd7625d972922eda3babd0 - updated the commit to keep the unmask instead of dropping it.

This PR should be merged together with https://github.com/flatcar/portage-stable/pull/406.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1100/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
