### PR TITLE
profiles: accept keywords ~arm64 for dev-vcs/git 2.38.3 for main

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -15,6 +15,9 @@
 # needed to force enable bpftool for arm64
 =dev-util/bpftool-5.19.8 **
 
+# needed to address CVE-2022-23521, CVE-2022-41903
+=dev-vcs/git-2.38.3 ~arm64
+
 =net-dns/c-ares-1.17.2 ~arm64
 =net-firewall/conntrack-tools-1.4.6-r1 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64


### PR DESCRIPTION
Accept keywords `~arm64` for `dev-vcs/git` 2.38.3, mainly to address [CVE-2022-23521](https://nvd.nist.gov/vuln/detail/CVE-2022-23521), [CVE-2022-41903](https://nvd.nist.gov/vuln/detail/CVE-2022-41903).

This PR should be merged together with https://github.com/flatcar/portage-stable/pull/408.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/541/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
