### PR TITLE
coreos-base/coreos-init: Skip first boot helper if Ignition did not run

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="f82fb0b53b73f8f5a68216582906ce9308fb8e1c" # flatcar-master
+	CROS_WORKON_COMMIT="11d9562a42276bdd7887faa43af04c9af1d2b2a8" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/init/pull/87
to give a nicer skip message in the log and also make clear that this is not a bug.

## How to use


## Testing done

None, just manual testing in the linked PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) ← not needed
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
