### PR TITLE
app-emulation/cri-tools: build with Go 1.18 for flatcar-3374

### DIFF
--- a/app-emulation/cri-tools/cri-tools-1.24.2.ebuild
+++ b/app-emulation/cri-tools/cri-tools-1.24.2.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 # Flatcar: remove bash-completion, inherit coreos-go
 inherit go-module coreos-go
 
-COREOS_GO_VERSION="go1.19"
+COREOS_GO_VERSION="go1.18"
 COREOS_GO_PACKAGE="github.com/kubernetes-sigs/cri-tools"
 COREOS_GO_MOD="vendor"
 


### PR DESCRIPTION
As `flatcar-3374` branch does not have Go 1.19, build fails due to a missing Go runtime. Downgrade `COREOS_GO_VERSION` to go1.18 to fix the build issue.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1197/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
