### PR TITLE
coreos-base/coreos-init: Don't create a nested symlink when it exists

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="11d9562a42276bdd7887faa43af04c9af1d2b2a8" # flatcar-master
+	CROS_WORKON_COMMIT="ef534d83fb5ccfa3498e18e0fc7fac6d63aa82ef" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in the motdgen change
https://github.com/flatcar/init/pull/88
to not create a broken symlink in the symlinked /run/flatcar/ directory if the directory symlink /run/coreos already exists.

## How to use

No backport needed

## Testing done

None, only manual testing in  linked PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) ← not needed
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
