### PR TITLE
Apply new Flatcar change of using the combined systemd log format

### DIFF
--- a/changelog/changes/2023-02-09-systemd.md
+++ b/changelog/changes/2023-02-09-systemd.md
@@ -1,0 +1,1 @@
+- Switched systemd log reporting to the combined format of both unit description, as before, and now the unit name to easily find the unit ([coreos-overlay#2436](https://github.com/flatcar/coreos-overlay/pull/2436))

--- a/sys-apps/systemd/systemd-252.5.ebuild
+++ b/sys-apps/systemd/systemd-252.5.ebuild
@@ -409,6 +409,9 @@ multilib_src_configure() {
 		# for https://github.com/flatcar/Flatcar/issues/36
 		-Ddefault-net-naming-scheme=latest
 
+		# Flatcar: Combined log format: name plus description
+		-Dstatus-unit-format-default=combined
+
 		# Flatcar: Unported options, still needed?
 		-Dquotaon-path=/usr/sbin/quotaon
 		-Dquotacheck-path=/usr/sbin/quotacheck


### PR DESCRIPTION
The boot log only showed the unit descriptions which made it hard to know what unit was meant.
Switch to the combined unit status reporting that includes the unit name.

## How to use


## Testing done

[Done](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1256/cldsv/) ← Requires [mantle kola changes](https://github.com/flatcar/mantle/pull/411) because the journal log line for `cl.network.initramfs.second-boot` changes

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
