### PR TITLE
profiles: update sys-devel/gcc to 11.3.1_p20230120-r1

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -34,6 +34,10 @@
 # needed to force enable ipvsadm for arm64
 =sys-cluster/ipvsadm-1.27-r1 **
 
+# needed to enable gcc 11.3.1_p20230120-r1 for arm64, a required version
+# for fixing build issues in glibc with gcc, w.r.t USE flag cet.
+=sys-devel/gcc-11.3.1_p20230120-r1 ~arm64
+
 =sys-firmware/edk2-aarch64-18.02 **
 =sys-fs/btrfs-progs-4.19.1 ~arm64
 =sys-libs/libselinux-3.1-r2 ~arm64

--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -22,7 +22,7 @@
 # up. Drop this when we switch to it.
 >=dev-lang/python-3.10
 
-# sys-devel/gcc-11.3.1_p20221209 is the latest gcc version that is
-# stable on both amd64 and arm64. There are newer versions of gcc
-# which are stable only on one of them, so mask them.
->sys-devel/gcc-11.3.1_p20221209
+# sys-devel/gcc-11.3.1_p20230120-r1 is the latest stable gcc version
+# that fixes the CET build issue of glibc. There are newer versions of
+# gcc that are not tested enough for CET, so mask them.
+>sys-devel/gcc-11.3.1_p20230120-r1


### PR DESCRIPTION
Since the new USE flag `cet` became the default in profiles of portage-stable, SDK bootstrap using gcc 11.3.1_p20221209 started to fail at `sys-libs/glibc`.

```
in function `dl_open_worker_begin':
 dl-open.c:(.text+0xab4c): undefined reference to `_dl_cet_open_check'
```

That is because gcc is not correctly configured for CET.

That issue was fixed in recent upstream GCC versions, e.g. 11.3.1_p20221209-r1 or 11.3.1_p20230120-r1.
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=016184c289f2cc6c6ade496a700a12f135fbae07
https://gitweb.gentoo.org/proj/gcc-patches.git/commit/?id=15daf0510a5fab17cd556261d688a6618391a0c1
However, gcc of Flatcar, 11.3.1_p20221209, does not have the fix.

Update `sys-devel/gcc` to 11.3.1_p20230120-r1 to fix that issue.

Also accept ~arm64 to keep the same version for both arches.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/624/ (2-phase builds)

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
