### PR TITLE
coreos-base/coreos-init: Exclude K8s' special interfaces

### DIFF
--- a/changelog/bugfixes/2023-02-20-preserve-kubernetes-interfaces.md
+++ b/changelog/bugfixes/2023-02-20-preserve-kubernetes-interfaces.md
@@ -1,0 +1,1 @@
+- Excluded the special Kubernetes network interfaces `nodelocaldns` and `kube-ipvs0` from being managed with systemd-networkd which interfered with the setup ([init#89](https://github.com/flatcar/init/pull/89)).

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="ef534d83fb5ccfa3498e18e0fc7fac6d63aa82ef" # flatcar-master
+	CROS_WORKON_COMMIT="c97767857f7d9aff54645796635814f7be423e31" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/init/pull/89
to set the Kubernetes interfaces nodelocaldns and kube-ipvs0 as Unmanaged in networkd to prevent configuration conflicts.

## How to use

We can backport it (down to LTS or rather Stable to prevent regressions in LTS?) with backports branches for the "init" repo.

## Testing done

[Kola on all platforms](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1331/cldsv/)

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
