### PR TITLE
sys-kernel/bootengine: Set up /etc as overlay mount

### DIFF
--- a/changelog/changes/2023-02-20-etc-overlayfs.md
+++ b/changelog/changes/2023-02-20-etc-overlayfs.md
@@ -1,0 +1,1 @@
+- `/etc` is now set up as overlayfs with the original `/etc` folder being the store for changed files/directories and `/usr/share/flatcar/etc` providing the lower default directory tree ([bootengine#53](https://github.com/flatcar/bootengine/pull/53), [scripts#666](https://github.com/flatcar/scripts/pull/666))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="aa8a19eb8e555d75535632600a353ea4cb5576eb" # flatcar-master
+	CROS_WORKON_COMMIT="98a903c775dc0dea3db45e5ca730d7be4d480cf2" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/bootengine/pull/53
to provide files in /etc through an overlay mount from /usr/share/flatcar/etc - essentially giving us a 3-way merge of config files that allows us to update /etc while keeping user changes.

## How to use

Together with https://github.com/flatcar/scripts/pull/666

## Testing done

See https://github.com/flatcar/bootengine/pull/53

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
