### PR TITLE
app-emulation/containerd: default to Go 1.19

### DIFF
--- a/app-emulation/containerd/containerd-9999.ebuild
+++ b/app-emulation/containerd/containerd-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 GITHUB_URI="github.com/containerd/containerd"
 COREOS_GO_PACKAGE="${GITHUB_URI}"
-COREOS_GO_VERSION="go1.18"
+COREOS_GO_VERSION="go1.19"
 
 if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://${GITHUB_URI}.git"


### PR DESCRIPTION
Since containerd 1.6.18, containerd is built with Go 1.19 by default. Following that, update the default Go version to 1.19.
See also https://github.com/containerd/containerd/commit/54ead5b7b71a.

Note: docker, docker-cli, docker-proxy, docker-runc still need Go 1.18.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1342/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
