### PR TITLE
coreos-base/coreos-init: Fix dummy dev default networkd unit exclusion

### DIFF
--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="c97767857f7d9aff54645796635814f7be423e31" # flatcar-master
+	CROS_WORKON_COMMIT="bb97f96d36060483be2edee78acf98359ca28180" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/init/pull/90
to fix the dummy interface exclusion rule in the default networkd unit. It was supposed to work before but didn't. With it we wouldn't have needed the special exclusions for Kubernetes interfaces.

## How to use

## Testing done

Manual in linked PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) ← not sure we really need this?
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
