### PR TITLE
profiles: accept keywords for e2fsprogs 1.46.6

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -34,6 +34,9 @@
 
 =sys-fs/cryptsetup-2.4.1-r1 ~amd64 ~arm64
 
+# Required for addressing CVE-2022-1304
+=sys-fs/e2fsprogs-1.46.6 ~amd64 ~arm64
+
 # Keep iproute in sync with kernel version.
 =sys-apps/iproute2-5.15.0 ~amd64 ~arm64
 


### PR DESCRIPTION
Accept keywords `~amd64` and `~arm64` for `sys-fs/e2fsprogs`, mainly to address [CVE-2022-1304](https://nvd.nist.gov/vuln/detail/CVE-2022-1304).

This PR should be merged together with https://github.com/flatcar/portage-stable/pull/420.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/661/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. (not needed)
