### PR TITLE
profiles: accept keyword ~arm64 for net-dns/dnsmasq 2.89

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -16,6 +16,10 @@
 =dev-util/bpftool-5.19.12 **
 
 =net-dns/c-ares-1.17.2 ~arm64
+
+# needed to address CVE-2022-0934
+=net-dns/dnsmasq-2.89 ~arm64
+
 =net-firewall/conntrack-tools-1.4.6-r1 ~arm64
 =net-libs/libnetfilter_cthelper-1.0.0-r1 ~arm64
 =net-libs/libnetfilter_cttimeout-1.0.0-r1 ~arm64


### PR DESCRIPTION
Accept keyword `~arm64` for `net-dns/dnsmasq` 2.89, to keep the same version 2.89 for both arches, addressing [CVE-2022-0934](https://nvd.nist.gov/vuln/detail/CVE-2022-0934).

This PR should be merged together with https://github.com/flatcar/portage-stable/pull/421.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/662/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
