### PR TITLE
profiles: Add KEYWORDS to update intel-microcode to 20230214_p20230212

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -42,3 +42,7 @@
 =sys-libs/liburing-2.1-r2 ~amd64 ~arm64
 
 =app-crypt/adcli-0.9.2 ~amd64 ~arm64
+
+# update intel-microcode to latest version.
+# Also required for CVE-2022-21216, CVE-2022-33196, CVE-2022-38090
+=sys-firmware/intel-microcode-20230214_p20230212 ~amd64


### PR DESCRIPTION
#  profiles: Add KEYWORDS to update intel-microcode to 20230214_p20230212

To be merged with https://github.com/flatcar/portage-stable/pull/422

## Testing done

~CI Passed http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1348/cldsv/~
CI Running http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1366/cldsv/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
