### PR TITLE
Support selective OS resets

### DIFF
--- a/changelog/changes/2023-02-23-os-reset.md
+++ b/changelog/changes/2023-02-23-os-reset.md
@@ -1,0 +1,1 @@
+- Added a new `flatcar-reset` tool and boot logic for selective OS resets to reconfigure the system with Ignition while avoiding config drift ([bootengine#55](https://github.com/flatcar/bootengine/pull/55), [init#91](https://github.com/flatcar/init/pull/91))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="bb97f96d36060483be2edee78acf98359ca28180" # flatcar-master
+	CROS_WORKON_COMMIT="7eaf6029c4a0df9996d027a54ac4e716aa305d58" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="786e45cc6669bda7b2e51ab59c095e66f1b37f6c" # flatcar-master
+	CROS_WORKON_COMMIT="7426121a9aa88fb8e989d6fa102093605a4789e3" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/bootengine/pull/55 and
https://github.com/flatcar/init/pull/91 for a `flatcar-reset` tool and boot logic for selective OS resets, cleaning the rootfs of old state while keeping wanted paths, e.g., when reconfiguring the system with Ignition.

## How to use

Blocked on https://github.com/flatcar/coreos-overlay/pull/2482

## Testing done

See linked bootengine PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
