### PR TITLE
profiles: Enable systemd[elfutils] USE flag for board

### DIFF
--- a/changelog/changes/2023-03-08-systemd-elfutils.md
+++ b/changelog/changes/2023-03-08-systemd-elfutils.md
@@ -1,0 +1,1 @@
+- Enabled elfutils support in systemd-coredump. A backtrace will now appear in the journal for any program that dumps core ([coreos-overlay#2489](https://github.com/flatcar/coreos-overlay/pull/2489))

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -24,7 +24,7 @@ sys-libs/ncurses	minimal
 sys-libs/pam		audit
 
 # enable journal gateway, bootctl and container features
-sys-apps/systemd audit gnuefi http importd iptables
+sys-apps/systemd audit elfutils gnuefi http importd iptables
 
 # epoll is needed for systemd-journal-remote to work. coreos/bugs#919
 net-libs/libmicrohttpd epoll


### PR DESCRIPTION
# profiles: Enable systemd[elfutils] USE flag for board
Elfutils is already part of the usr partition, but currently not enabled in systemd-coredump. Systemd-coredump therefore fails with:

  elfutils disabled, parsing ELF objects not supported.

Enable the elfutils flag for systemd to make this work.

## How to use

Dump core and check journal for messages.

## Testing done

Haven't tested, but will try it out once CI builds images.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
