### PR TITLE
sys-kernel/bootengine: Make initrd-setup-root more resilient

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="7426121a9aa88fb8e989d6fa102093605a4789e3" # flatcar-master
+	CROS_WORKON_COMMIT="0ba568efbcbb4112b3adedadbf46b753f757fe36" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/bootengine/pull/56
to ensure that even with a rerun from the initrd or with a deletion of /etc/passwd we are able to boot.

## How to use


## Testing done

see linked PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
