### PR TITLE
sys-apps/baselayout: Only relabel a minimal set of /etc files

### DIFF
--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="ef610cfd99190ba33b5f6b27eb66dddc299ee332" # flatcar-master
+	CROS_WORKON_COMMIT="9082621e94ee6a1cdad9e15aa17a747d46c33c6f" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/baselayout/pull/28 to fix a regression in https://github.com/flatcar/baselayout/pull/24 due to how systemd-tmpfiles' Z rule seems to cause unnecessary changes in files.


## How to use


## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
