### PR TITLE
coreos-base/coreos-init: Distribute new sub key

### DIFF
--- a/changelog/changes/2023-03-09-image-signing-key.md
+++ b/changelog/changes/2023-03-09-image-signing-key.md
@@ -1,0 +1,1 @@
+- Added new image signing pub key to `flatcar-install`, needed for download verification of releases built from July 2023 onwards, if you have copies of `flatcar-install` or the image signing pub key, you need to update them as well ([init#92](https://github.com/flatcar/init/pull/92))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="7eaf6029c4a0df9996d027a54ac4e716aa305d58" # flatcar-master
+	CROS_WORKON_COMMIT="fbb1ec8e9d95598d65e4eac408dbc5f75b9b6138" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/init/pull/92 to distribute the new sub key before we start signing with it from July.


## How to use

Backport to all branches, via backport branch for init repo

## Testing done
