### PR TITLE
coreos-base/coreos: Add pigz to production image

### DIFF
--- a/changelog/changes/2023-03-09-pigz.md
+++ b/changelog/changes/2023-03-09-pigz.md
@@ -1,1 +1,1 @@
-- Added pigz to the production image. The parallel gzip implementation is useful to speed up the decompression time spent for large container image imports/exports.
+- Added `pigz` to the image, a parallel gzip implementation, which is useful to speed up the (de)compression for large container image imports/exports ([coreos-overlay#2504](https://github.com/flatcar/coreos-overlay/pull/2504))

--- a/changelog/changes/2023-03-09-pigz.md
+++ b/changelog/changes/2023-03-09-pigz.md
@@ -1,0 +1,1 @@
+- Added pigz to the production image. The parallel gzip implementation is useful to speed up the decompression time spent for large container image imports/exports.

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -91,6 +91,7 @@ RDEPEND="${RDEPEND}
 	app-arch/bzip2
 	app-arch/lbzip2
 	app-arch/lz4
+	app-arch/pigz
 	app-arch/xz-utils
 	app-arch/zstd
 	app-arch/tar


### PR DESCRIPTION
For https://github.com/flatcar/Flatcar/issues/965

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1464/cldsv

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
