### PR TITLE
profiles: Accept license for sys-firmware/intel-microcode

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -59,7 +59,8 @@ USE="${USE} bindist"
 # no-source-code - license for sys-kernel/coreos-firmware
 # freedist - license for sys-kernel/coreos-kernel
 # BSD-2-Clause-Patent - license for sys-firmware/edk2-aarch64
-ACCEPT_LICENSE="${ACCEPT_LICENSE} netperf no-source-code freedist BSD-2-Clause-Patent"
+# intel-ucode - license for sys-firmware/intel-microcode
+ACCEPT_LICENSE="${ACCEPT_LICENSE} netperf no-source-code freedist BSD-2-Clause-Patent intel-ucode"
 
 # Favor our own mirrors over Gentoo's
 GENTOO_MIRRORS="


### PR DESCRIPTION
I'm not sure how this package slipped through the CI earlier, but now it couldn't be built because it's license was not accepted. Fix this by adding intel-ucode license to ACCEPT_LICENSE.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1471/cldsv
