### PR TITLE
sys-kernel/bootengine: Prevent OEM mount point from showing up early

### DIFF
--- a/changelog/bugfixes/2023-03-20-ignition-oem-partition.md
+++ b/changelog/bugfixes/2023-03-20-ignition-oem-partition.md
@@ -1,0 +1,1 @@
+- Restored the support to specify OEM partition files in Ignition when `/usr/share/oem` is given as initrd mount point ([bootengine#58](https://github.com/flatcar/bootengine/pull/58))

--- a/changelog/changes/2023-03-20-ignition-oem-files.md
+++ b/changelog/changes/2023-03-20-ignition-oem-files.md
@@ -1,0 +1,1 @@
+- Specifying the OEM filesystem in Ignition to write files to `/usr/share/oem` is not needed anymore ([bootengine#58](https://github.com/flatcar/bootengine/pull/58))

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="0ba568efbcbb4112b3adedadbf46b753f757fe36" # flatcar-master
+	CROS_WORKON_COMMIT="3ba6216024c75d502b9696d05f4f02594d52efbb" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/bootengine/pull/58
to prevent the OEM mount point from showing up before Ignition mounts. It also makes it simpler to write files to the OEM partition without having to specify the partition first as initrd mount point.

Fixes https://github.com/flatcar/Flatcar/issues/979

## How to use


## Testing done

See linked PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
