### PR TITLE
emerge-gitclone: bump to include support for git ref versions

### DIFF
--- a/coreos-base/emerge-gitclone/emerge-gitclone-9999.ebuild
+++ b/coreos-base/emerge-gitclone/emerge-gitclone-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_LOCALDIR="src/platform"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="ce789b660ecd42043312329a4b2f7ddcc2a8c033" # flatcar-master
+	CROS_WORKON_COMMIT="401e84df7b12b0f385879583003a7cc0bd9bbc60" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This change bumps the CROS_WORKON_COMMIT of emerge-gitclone to include the latest flatcar-master tip. emerge-gitclone now supports developer OS versions and uses the version's git ref suffix to check out the correct scripts repo version.

See https://github.com/flatcar/flatcar-dev-util/commit/401e84df7b12b0f385879583003a7cc0bd9bbc60 for details.

The change should be cherry-picked to all active maintenance branches (including LTS) as it un-blocks running tests in github actions. See https://github.com/flatcar/scripts/pull/696#issuecomment-1482850809 for more details.