### PR TITLE
Use tmpfiles to set up /var/log/journal/ from initrd

### DIFF
--- a/changelog/bugfixes/2023-03-30-var-log-journal.md
+++ b/changelog/bugfixes/2023-03-30-var-log-journal.md
@@ -1,0 +1,1 @@
+- Ensured that `/var/log/journal/` is created early enough for systemd-journald to persist the logs on first boot ([bootengine#60](https://github.com/flatcar/bootengine/pull/60), [baselayout#29](https://github.com/flatcar/baselayout/pull/29))

--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -9,7 +9,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="d4d6da73919bacc5b05a012d3d00dc8e2d669c0d" # flatcar-master
+	CROS_WORKON_COMMIT="f55f20a58997b0cdf7d85e90d1a7050a5e19c7ae" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="dcd4b1e4e348384834e9cb456e91282d77f18c80" # flatcar-master
+	CROS_WORKON_COMMIT="d3cc0f4b1dce6a5084a8a909810efc30c367020b" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/bootengine/pull/60 and https://github.com/flatcar/baselayout/pull/29 to fix the persisting of the journal on first boot.


## How to use

Backport to Alpha

## Testing done

See linked bootengine PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
