### PR TITLE
coreos-base/coreos-init: Add preview/backup/restore to flatcar-reset

### DIFF
--- a/changelog/changes/2023-04-05-os-reset-backup.md
+++ b/changelog/changes/2023-04-05-os-reset-backup.md
@@ -1,0 +1,1 @@
+- Improved the OS reset tool to offer preview, backup and restore ([init#94](https://github.com/flatcar/init/pull/94))

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="fbb1ec8e9d95598d65e4eac408dbc5f75b9b6138" # flatcar-master
+	CROS_WORKON_COMMIT="17224c8d6f71b17676bbcf34919072fb67a6bf4c" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/init/pull/94 to prevent data loss by having a preview mode and a backup/restore option.

## How to use
Backport to Alpha

## Testing done

Manually in the linked PR
[CI](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1606/cldsv/)

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
